### PR TITLE
Add data extraction utility and tests

### DIFF
--- a/dataUtils.js
+++ b/dataUtils.js
@@ -1,0 +1,16 @@
+function extractChartData(readings) {
+  const labels = [];
+  const temps = [];
+  const hums = [];
+  const presses = [];
+  for (const reading of readings) {
+    const ts = new Date(reading.timestamp);
+    labels.push(ts.toLocaleTimeString('en-GB'));
+    temps.push(reading.temperature.toFixed(1));
+    hums.push(reading.humidity.toFixed(0));
+    presses.push(reading.pressure.toFixed(1));
+  }
+  return { labels, temps, hums, presses };
+}
+
+module.exports = { extractChartData };

--- a/dataUtils.test.js
+++ b/dataUtils.test.js
@@ -1,0 +1,30 @@
+/**
+ * Jest tests verifying extractChartData converts sensor readings
+ * into correctly formatted arrays for chart labels, temperatures,
+ * humidities, and pressures.
+ */
+const { extractChartData } = require('./dataUtils');
+
+describe('extractChartData', () => {
+  const sampleReadings = [
+    { timestamp: '2024-01-01T12:00:00Z', temperature: 20.123, humidity: 49.6, pressure: 1012.34 },
+    { timestamp: '2024-01-01T13:00:00Z', temperature: 21.789, humidity: 50.4, pressure: 1010.12 }
+  ];
+
+  test('returns arrays matching number of readings', () => {
+    const result = extractChartData(sampleReadings);
+    expect(result.labels).toHaveLength(sampleReadings.length);
+    expect(result.temps).toHaveLength(sampleReadings.length);
+    expect(result.hums).toHaveLength(sampleReadings.length);
+    expect(result.presses).toHaveLength(sampleReadings.length);
+  });
+
+  test('formats values and timestamps correctly', () => {
+    const result = extractChartData(sampleReadings);
+    const expectedLabels = sampleReadings.map(r => new Date(r.timestamp).toLocaleTimeString('en-GB'));
+    expect(result.labels).toEqual(expectedLabels);
+    expect(result.temps).toEqual(['20.1', '21.8']);
+    expect(result.hums).toEqual(['50', '50']);
+    expect(result.presses).toEqual(['1012.3', '1010.1']);
+  });
+});


### PR DESCRIPTION
## Summary
- add `extractChartData` utility to prepare chart data from sensor readings
- add two Jest tests covering array lengths and formatting logic
- document test coverage with a descriptive header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f841aa83883278d28e3708f8e3035